### PR TITLE
Add dependency of fastjson.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>fastjson</artifactId>
+			<version>1.2.31</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
修复 invoke 时报错的 BUG
dubbo version: 2.5.7
```
dubbo>invoke com.alibaba.dubbo.test.docker.DemoService.hello("world")
Invalid json argument, cause: com/alibaba/fastjson/JSON
```

Ref: https://github.com/alibaba/dubbo/issues/844