### PR TITLE
Replace the zookeeper address 127.0.0.1 with link name zkserver in or…

### DIFF
--- a/src/main/resources/dubbo-docker-provider.xml
+++ b/src/main/resources/dubbo-docker-provider.xml
@@ -22,7 +22,7 @@
 
     <dubbo:application name="dubbo-docker-sample"/>
 
-    <dubbo:registry client="curator" address="zookeeper://127.0.0.1:2181"/>
+    <dubbo:registry client="curator" address="zookeeper://zkserver:2181"/>
 
     <!-- 用dubbo协议在20880端口暴露服务 -->
     <dubbo:protocol name="dubbo" port="20880" />


### PR DESCRIPTION
Fix the issue that the container failed to connect to zookeeper because of the hard coded address **127.0.0.1** 

2018-03-11 08:56:09.432  INFO 1 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Opening socket connection to server 127.0.0.1/127.0.0.1:2181. Will not attempt to authenticate using SASL (unknown error)
2018-03-11 08:56:09.433  WARN 1 --- [127.0.0.1:2181)] org.apache.zookeeper.ClientCnxn          : Session 0x0 for server null, unexpected error, closing socket connection and attempting reconnect

java.net.ConnectException: Connection refused
        at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method) ~[na:1.8.0_151]
        at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:717) ~[na:1.8.0_151]
        at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:361) ~[zookeeper-3.4.9.jar!/:3.4.9-1757313]
        at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1141) ~[zookeeper-3.4.9.jar!/:3.4.9-1757313]
2018-03-11 08:56:10.085 ERROR 1 --- [           main] org.apache.curator.ConnectionState       : Connection timed out for connection string (127.0.0.1:2181) and timeout (5000) / elapsed (5154)